### PR TITLE
Fix classpath and separate gear constants

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -7,6 +7,8 @@
 	<classpathentry kind="var" path="cscore" sourcepath="cscore.sources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="var" path="USERLIBS_DIR/CTRLib.jar"/>
+	<classpathentry kind="var" path="USERLIBS_DIR/TalonSRXLibJava.jar"/>
+	<classpathentry kind="var" path="USERLIBS_DIR/CTRLib-javadoc.jar"/>
 	<classpathentry kind="lib" path="lib/jssc.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/org/usfirst/frc/team4183/robot/subsystems/GearHandlerSubsystem.java
+++ b/src/org/usfirst/frc/team4183/robot/subsystems/GearHandlerSubsystem.java
@@ -12,8 +12,8 @@ public class GearHandlerSubsystem extends Subsystem {
 	
 	DoubleSolenoid gearGateSolenoid = new DoubleSolenoid(RobotMap.GEAR_HANDLER_PNEUMA_OPEN_CHANNEL, RobotMap.GEAR_HANDLER_PNEUMA_CLOSED_CHANNEL); 
 	private final CANTalon gearHandlerMotor = new CANTalon(RobotMap.GEAR_HANDLER_MOTOR_ID);
-	private static final double MOTOR_SPEED_PVBUS = 1.0;
-	
+	private static final double GEAR_RECEIVE_MOTOR_SPEED_PVBUS = 1.0;
+	private static final double BALL_RECEIVE_MOTOR_SPEED_PVBUS = -1.0;	
 	public void enable() {}
 	
 	public void disable() {
@@ -35,11 +35,11 @@ public class GearHandlerSubsystem extends Subsystem {
 	}
 	
 	public void spinRollerBalls() {
-		gearHandlerMotor.set(MOTOR_SPEED_PVBUS);
+		gearHandlerMotor.set(BALL_RECEIVE_MOTOR_SPEED_PVBUS);
 	}
 	
 	public void spinRollerGear() {
-		gearHandlerMotor.set(-MOTOR_SPEED_PVBUS);
+		gearHandlerMotor.set(GEAR_RECEIVE_MOTOR_SPEED_PVBUS);
 	}
 	
 	public void stopRoller() {


### PR DESCRIPTION
Gear handler uses two constants for clarity; classpath was corrupted by previous commit from multiple sources.