### PR TITLE
Move compressor object

### DIFF
--- a/src/org/usfirst/frc/team4183/robot/Robot.java
+++ b/src/org/usfirst/frc/team4183/robot/Robot.java
@@ -1,6 +1,7 @@
 
 package org.usfirst.frc.team4183.robot;
 
+import edu.wpi.first.wpilibj.Compressor;
 import edu.wpi.first.wpilibj.IterativeRobot;
 import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.command.Scheduler;
@@ -31,6 +32,8 @@ public class Robot extends IterativeRobot {
 	public static final DriveSubsystem driveSubsystem = new DriveSubsystem();
 	public static final GearHandlerSubsystem gearHandlerSubsystem = new GearHandlerSubsystem();
 
+	private static final Compressor compressor = new Compressor(RobotMap.PNEUMATICS_CONTROL_MODULE_ID);
+
 	public static OI oi;
 
 	
@@ -50,6 +53,14 @@ public class Robot extends IterativeRobot {
 	 */
 	@Override
 	public void robotInit() {
+		
+		// Start pressurizing the tanks as soon as we are initialized
+		// NOTE: The compressor object is foundation of all things
+		// connected to the Pneumatics Control Module (PCM) so does
+		// not belong to any one subsystem.
+		compressor.setClosedLoopControl(true);
+		
+		
 		oi = OI.instance();
 				
 		// Add all subsystems for debugging

--- a/src/org/usfirst/frc/team4183/robot/RobotMap.java
+++ b/src/org/usfirst/frc/team4183/robot/RobotMap.java
@@ -44,5 +44,5 @@ public class RobotMap {
 	public static final int GEAR_HANDLER_PNEUMA_OPEN_CHANNEL = 2;
 	public static final int GEAR_HANDLER_PNEUMA_CLOSED_CHANNEL = 3;
 	
-	public static final int COMPRESSOR_CHANNEL = 0;
+	public static final int PNEUMATICS_CONTROL_MODULE_ID = 0;
 }

--- a/src/org/usfirst/frc/team4183/robot/subsystems/GearHandlerSubsystem.java
+++ b/src/org/usfirst/frc/team4183/robot/subsystems/GearHandlerSubsystem.java
@@ -4,7 +4,6 @@ package org.usfirst.frc.team4183.robot.subsystems;
 import org.usfirst.frc.team4183.robot.RobotMap;
 import org.usfirst.frc.team4183.robot.commands.GearHandlerSubsystem.Idle;
 
-import edu.wpi.first.wpilibj.Compressor;
 import edu.wpi.first.wpilibj.DoubleSolenoid;
 import com.ctre.CANTalon;
 import edu.wpi.first.wpilibj.command.Subsystem;
@@ -12,16 +11,12 @@ import edu.wpi.first.wpilibj.command.Subsystem;
 public class GearHandlerSubsystem extends Subsystem {
 	
 	private final DoubleSolenoid gearGateSolenoid = new DoubleSolenoid(RobotMap.GEAR_HANDLER_PNEUMA_OPEN_CHANNEL, RobotMap.GEAR_HANDLER_PNEUMA_CLOSED_CHANNEL); 
+
 	private final CANTalon gearHandlerMotor = new CANTalon(RobotMap.GEAR_HANDLER_MOTOR_ID);
 	private static final double GEAR_RECEIVE_MOTOR_SPEED_PVBUS = 1.0;
 	private static final double BALL_RECEIVE_MOTOR_SPEED_PVBUS = -1.0;
-	private final Compressor compressor = new Compressor(RobotMap.COMPRESSOR_CHANNEL);
 	
-	public GearHandlerSubsystem(){
-		compressor.setClosedLoopControl(true);
-	}
-	
-	public void enable() {
+	public void enable(){
 	}
 		
 	public void disable() {


### PR DESCRIPTION
Compressor object does not belong to any one subsystem and must be  initialized (closed loop enabled) by the robot, not at construction